### PR TITLE
Fix libvirt provider private network

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure("2") do |config|
   config.vm.provider :libvirt do |vm|
     vm.memory = "8192"
     vm.cpus = 2
+    vm.qemu_use_session = false
   end
 
   config.vm.provision "shell", inline: <<-SHELL


### PR DESCRIPTION
Fix libvirt provider private network

On the new vagrant-libvirt-0.0.45-1.fc30.noarch, the default
was updated, providing the user with a qemu session, which does
not play weel with vagrant's private networks.
This was reported upstream in [1] and also tracked in bz [2].

To workaround it, whenever private networks are required, we should
update the vagrantfiles, disabling the qemu session, as per [0].

[0] - https://fedoraproject.org/wiki/Changes/Vagrant_2.2_with_QEMU_Session#Upgrade.2Fcompatibility_impact
[1] - https://github.com/vagrant-libvirt/vagrant-libvirt/issues/958#issuecomment-481106254
[2] - https://bugzilla.redhat.com/show_bug.cgi?id=1697773

Signed-off-by: Miguel Duarte Barroso <mdbarroso@redhat.com>